### PR TITLE
5 disconnect fails due to expired token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@pexip/plugin-api": "18.0.0",
+                "@pexip/plugin-api": "19.1.0",
                 "eventemitter3": "^5.0.1"
             },
             "devDependencies": {
-                "@typescript-eslint/eslint-plugin": "^6.9.0",
-                "eslint": "^8.52.0",
-                "eslint-config-standard-with-typescript": "^39.1.1",
-                "eslint-plugin-import": "^2.29.0",
-                "eslint-plugin-n": "^16.2.0",
+                "@typescript-eslint/eslint-plugin": "^6.4.0",
+                "eslint": "^8.57.0",
+                "eslint-config-standard-with-typescript": "^43.0.1",
+                "eslint-plugin-import": "^2.29.1",
+                "eslint-plugin-n": "^16.6.2",
                 "eslint-plugin-promise": "^6.1.1",
-                "prettier": "^3.0.3",
-                "typescript": "^5.2.2",
-                "vite": "^4.5.0",
-                "vite-plugin-mkcert": "^1.16.0"
+                "prettier": "^3.2.5",
+                "typescript": "^5.4.2",
+                "vite": "^5.1.6",
+                "vite-plugin-mkcert": "^1.17.4"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -34,10 +34,26 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+            "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+            "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
             "cpu": [
                 "arm"
             ],
@@ -51,9 +67,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+            "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
             "cpu": [
                 "arm64"
             ],
@@ -67,9 +83,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+            "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
             "cpu": [
                 "x64"
             ],
@@ -83,9 +99,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+            "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
             "cpu": [
                 "arm64"
             ],
@@ -99,9 +115,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+            "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
             "cpu": [
                 "x64"
             ],
@@ -115,9 +131,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+            "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
             "cpu": [
                 "arm64"
             ],
@@ -131,9 +147,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+            "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
             "cpu": [
                 "x64"
             ],
@@ -147,9 +163,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+            "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
             "cpu": [
                 "arm"
             ],
@@ -163,9 +179,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+            "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
             "cpu": [
                 "arm64"
             ],
@@ -179,9 +195,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+            "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
             "cpu": [
                 "ia32"
             ],
@@ -195,9 +211,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+            "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
             "cpu": [
                 "loong64"
             ],
@@ -211,9 +227,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+            "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
             "cpu": [
                 "mips64el"
             ],
@@ -227,9 +243,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+            "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
             "cpu": [
                 "ppc64"
             ],
@@ -243,9 +259,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+            "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
             "cpu": [
                 "riscv64"
             ],
@@ -259,9 +275,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+            "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
             "cpu": [
                 "s390x"
             ],
@@ -275,9 +291,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+            "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
             "cpu": [
                 "x64"
             ],
@@ -291,9 +307,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+            "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
             "cpu": [
                 "x64"
             ],
@@ -307,9 +323,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+            "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
             "cpu": [
                 "x64"
             ],
@@ -323,9 +339,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+            "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
             "cpu": [
                 "x64"
             ],
@@ -339,9 +355,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+            "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
             "cpu": [
                 "arm64"
             ],
@@ -355,9 +371,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+            "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
             "cpu": [
                 "ia32"
             ],
@@ -371,9 +387,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+            "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
             "cpu": [
                 "x64"
             ],
@@ -411,9 +427,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -434,22 +450,22 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-            "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
@@ -470,9 +486,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+            "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -511,187 +527,171 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
             "dev": true,
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-            "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
+            "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
             "dev": true,
             "dependencies": {
-                "@octokit/auth-token": "^3.0.0",
-                "@octokit/graphql": "^5.0.0",
-                "@octokit/request": "^6.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-            "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
+            "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^9.0.0",
-                "is-plain-object": "^5.0.0",
+                "@octokit/types": "^12.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
+            "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
             "dev": true,
             "dependencies": {
-                "@octokit/request": "^6.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/request": "^8.0.1",
+                "@octokit/types": "^12.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "18.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-            "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
             "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-            "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
+            "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
             "dev": true,
             "dependencies": {
-                "@octokit/tsconfig": "^1.0.2",
-                "@octokit/types": "^9.2.3"
+                "@octokit/types": "^12.6.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=4"
+                "@octokit/core": "5"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+            "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
             "dev": true,
+            "engines": {
+                "node": ">= 18"
+            },
             "peerDependencies": {
-                "@octokit/core": ">=3"
+                "@octokit/core": "5"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-            "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^10.0.0"
+                "@octokit/types": "^12.6.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=3"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-            "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-            "dev": true,
-            "dependencies": {
-                "@octokit/openapi-types": "^18.0.0"
+                "@octokit/core": "5"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "6.2.8",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-            "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
+            "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/endpoint": "^7.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
-                "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
+                "@octokit/endpoint": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
+            "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^12.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "19.0.13",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
-            "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
+            "version": "20.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.2.tgz",
+            "integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/core": "^4.2.1",
-                "@octokit/plugin-paginate-rest": "^6.1.2",
-                "@octokit/plugin-request-log": "^1.0.4",
-                "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+                "@octokit/core": "^5.0.0",
+                "@octokit/plugin-paginate-rest": "^9.0.0",
+                "@octokit/plugin-request-log": "^4.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
-        "node_modules/@octokit/tsconfig": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-            "dev": true
-        },
         "node_modules/@octokit/types": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-            "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
             "dev": true,
             "dependencies": {
-                "@octokit/openapi-types": "^18.0.0"
+                "@octokit/openapi-types": "^20.0.0"
             }
         },
         "node_modules/@pexip/infinity-api": {
-            "version": "17.1.0",
-            "resolved": "https://registry.npmjs.org/@pexip/infinity-api/-/infinity-api-17.1.0.tgz",
-            "integrity": "sha512-/gSQjuulpFe/+C4MLLw8YzaJHpMz3t7zncfIizE85oQMrym89VJO4pI5QL5zyqxIAXycChcql0vn6RHTtHYAZw=="
+            "version": "17.3.0",
+            "resolved": "https://registry.npmjs.org/@pexip/infinity-api/-/infinity-api-17.3.0.tgz",
+            "integrity": "sha512-VbY+m1yuWYfAxVxSxABq4N4K8Ya6YXo9FcAvojkiwdCdLYO+UhQu4Zc39SpWsAOq+C9VQGLSYFhDpK2SGieOUQ=="
         },
         "node_modules/@pexip/plugin-api": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/@pexip/plugin-api/-/plugin-api-18.0.0.tgz",
-            "integrity": "sha512-UxFEoYOt48gOByHti8XLEjMpBo4eoLvjh+rf80wWXfDsjqskG2Jj5t0ZAjO3cbmy66DPNlS4gVCitJnAzqQHfQ==",
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/@pexip/plugin-api/-/plugin-api-19.1.0.tgz",
+            "integrity": "sha512-mC1xY7FZXuZY6GlWsgtmjh8q/mImsgWPmpNsrmgCTQ+pEmxuFDgQHV2m74b7FN8VBaq7+T33oqxeJkKoIHVZrw==",
             "dependencies": {
-                "@pexip/infinity-api": "17.1.0",
+                "@pexip/infinity-api": "17.3.0",
                 "@pexip/signal": "16.6.0",
                 "uuid": "^9.0.0"
             }
@@ -700,6 +700,181 @@
             "version": "16.6.0",
             "resolved": "https://registry.npmjs.org/@pexip/signal/-/signal-16.6.0.tgz",
             "integrity": "sha512-vJ7AgDvJ1yPU7yb7gaDcoQ58qvtRnOckFcjk6r9EuOQqxKDLJPGJJVSKSiiie0ORqE5Vq/vRYgyMSjKAYCRnxg=="
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
+            "integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
+            "integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
+            "integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
+            "integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
+            "integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
+            "integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
+            "integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
+            "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
+            "integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
+            "integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
+            "integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
+            "integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
+            "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.14",
@@ -915,9 +1090,9 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -1117,12 +1292,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-            "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.4",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -1159,6 +1334,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/builtin-modules": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+            "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/builtins": {
@@ -1446,9 +1633,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "version": "0.19.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+            "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -1458,28 +1645,29 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.18.20",
-                "@esbuild/android-arm64": "0.18.20",
-                "@esbuild/android-x64": "0.18.20",
-                "@esbuild/darwin-arm64": "0.18.20",
-                "@esbuild/darwin-x64": "0.18.20",
-                "@esbuild/freebsd-arm64": "0.18.20",
-                "@esbuild/freebsd-x64": "0.18.20",
-                "@esbuild/linux-arm": "0.18.20",
-                "@esbuild/linux-arm64": "0.18.20",
-                "@esbuild/linux-ia32": "0.18.20",
-                "@esbuild/linux-loong64": "0.18.20",
-                "@esbuild/linux-mips64el": "0.18.20",
-                "@esbuild/linux-ppc64": "0.18.20",
-                "@esbuild/linux-riscv64": "0.18.20",
-                "@esbuild/linux-s390x": "0.18.20",
-                "@esbuild/linux-x64": "0.18.20",
-                "@esbuild/netbsd-x64": "0.18.20",
-                "@esbuild/openbsd-x64": "0.18.20",
-                "@esbuild/sunos-x64": "0.18.20",
-                "@esbuild/win32-arm64": "0.18.20",
-                "@esbuild/win32-ia32": "0.18.20",
-                "@esbuild/win32-x64": "0.18.20"
+                "@esbuild/aix-ppc64": "0.19.12",
+                "@esbuild/android-arm": "0.19.12",
+                "@esbuild/android-arm64": "0.19.12",
+                "@esbuild/android-x64": "0.19.12",
+                "@esbuild/darwin-arm64": "0.19.12",
+                "@esbuild/darwin-x64": "0.19.12",
+                "@esbuild/freebsd-arm64": "0.19.12",
+                "@esbuild/freebsd-x64": "0.19.12",
+                "@esbuild/linux-arm": "0.19.12",
+                "@esbuild/linux-arm64": "0.19.12",
+                "@esbuild/linux-ia32": "0.19.12",
+                "@esbuild/linux-loong64": "0.19.12",
+                "@esbuild/linux-mips64el": "0.19.12",
+                "@esbuild/linux-ppc64": "0.19.12",
+                "@esbuild/linux-riscv64": "0.19.12",
+                "@esbuild/linux-s390x": "0.19.12",
+                "@esbuild/linux-x64": "0.19.12",
+                "@esbuild/netbsd-x64": "0.19.12",
+                "@esbuild/openbsd-x64": "0.19.12",
+                "@esbuild/sunos-x64": "0.19.12",
+                "@esbuild/win32-arm64": "0.19.12",
+                "@esbuild/win32-ia32": "0.19.12",
+                "@esbuild/win32-x64": "0.19.12"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -1495,16 +1683,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-            "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.52.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -1549,6 +1737,18 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint-compat-utils": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz",
+            "integrity": "sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
         "node_modules/eslint-config-standard": {
             "version": "17.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
@@ -1579,9 +1779,9 @@
             }
         },
         "node_modules/eslint-config-standard-with-typescript": {
-            "version": "39.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-39.1.1.tgz",
-            "integrity": "sha512-t6B5Ep8E4I18uuoYeYxINyqcXb2UbC0SOOTxRtBSt2JUs+EzeXbfe2oaiPs71AIdnoWhXDO2fYOHz8df3kV84A==",
+            "version": "43.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-43.0.1.tgz",
+            "integrity": "sha512-WfZ986+qzIzX6dcr4yGUyVb/l9N3Z8wPXCc5z/70fljs3UbWhhV+WxrfgsqMToRzuuyX9MqZ974pq2UPhDTOcA==",
             "dev": true,
             "dependencies": {
                 "@typescript-eslint/parser": "^6.4.0",
@@ -1643,13 +1843,14 @@
             }
         },
         "node_modules/eslint-plugin-es-x": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
-            "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
+            "integrity": "sha512-ODswlDSO0HJDzXU0XvgZ3lF3lS3XAZEossh15Q2UHjwrJggWeBoKqqEsLTZLXl+dh5eOAozG0zRcYtuE35oTuQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.1.2",
-                "@eslint-community/regexpp": "^4.6.0"
+                "@eslint-community/regexpp": "^4.6.0",
+                "eslint-compat-utils": "^0.1.2"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -1662,9 +1863,9 @@
             }
         },
         "node_modules/eslint-plugin-import": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-            "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
+            "version": "2.29.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+            "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
             "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.7",
@@ -1683,7 +1884,7 @@
                 "object.groupby": "^1.0.1",
                 "object.values": "^1.1.7",
                 "semver": "^6.3.1",
-                "tsconfig-paths": "^3.14.2"
+                "tsconfig-paths": "^3.15.0"
             },
             "engines": {
                 "node": ">=4"
@@ -1723,16 +1924,18 @@
             }
         },
         "node_modules/eslint-plugin-n": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.2.0.tgz",
-            "integrity": "sha512-AQER2jEyQOt1LG6JkGJCCIFotzmlcCZFur2wdKrp1JX2cNotC7Ae0BcD/4lLv3lUAArM9uNS8z/fsvXTd0L71g==",
+            "version": "16.6.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
+            "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "builtins": "^5.0.1",
-                "eslint-plugin-es-x": "^7.1.0",
+                "eslint-plugin-es-x": "^7.5.0",
                 "get-tsconfig": "^4.7.0",
+                "globals": "^13.24.0",
                 "ignore": "^5.2.4",
+                "is-builtin-module": "^3.2.1",
                 "is-core-module": "^2.12.1",
                 "minimatch": "^3.1.2",
                 "resolve": "^1.22.2",
@@ -1968,9 +2171,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "dev": true,
             "funding": [
                 {
@@ -2142,9 +2345,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.23.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-            "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -2396,6 +2599,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-builtin-module": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+            "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+            "dev": true,
+            "dependencies": {
+                "builtin-modules": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -2499,15 +2717,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-regex": {
@@ -2775,9 +2984,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
             "dev": true,
             "funding": [
                 {
@@ -2797,26 +3006,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/object-inspect": {
             "version": "1.13.1",
@@ -3029,9 +3218,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+            "version": "8.4.35",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+            "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
             "dev": true,
             "funding": [
                 {
@@ -3048,7 +3237,7 @@
                 }
             ],
             "dependencies": {
-                "nanoid": "^3.3.6",
+                "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             },
@@ -3066,9 +3255,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-            "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -3087,9 +3276,9 @@
             "dev": true
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -3193,18 +3382,34 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.29.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-            "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
+            "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
             "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=14.18.0",
+                "node": ">=18.0.0",
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.13.0",
+                "@rollup/rollup-android-arm64": "4.13.0",
+                "@rollup/rollup-darwin-arm64": "4.13.0",
+                "@rollup/rollup-darwin-x64": "4.13.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.13.0",
+                "@rollup/rollup-linux-arm64-musl": "4.13.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
+                "@rollup/rollup-linux-x64-gnu": "4.13.0",
+                "@rollup/rollup-linux-x64-musl": "4.13.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.13.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.13.0",
+                "@rollup/rollup-win32-x64-msvc": "4.13.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -3480,12 +3685,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
-        },
         "node_modules/ts-api-utils": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -3499,9 +3698,9 @@
             }
         },
         "node_modules/tsconfig-paths": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-            "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+            "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "dev": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
@@ -3600,9 +3799,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+            "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -3628,9 +3827,9 @@
             }
         },
         "node_modules/universal-user-agent": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
             "dev": true
         },
         "node_modules/uri-js": {
@@ -3655,29 +3854,29 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-            "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.6.tgz",
+            "integrity": "sha512-yYIAZs9nVfRJ/AiOLCA91zzhjsHUgMjB+EigzFb6W2XTLO8JixBCKCjvhKZaye+NKYHCrkv3Oh50dH9EdLU2RA==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.18.10",
-                "postcss": "^8.4.27",
-                "rollup": "^3.27.1"
+                "esbuild": "^0.19.3",
+                "postcss": "^8.4.35",
+                "rollup": "^4.2.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.2"
+                "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": ">= 14",
+                "@types/node": "^18.0.0 || >=20.0.0",
                 "less": "*",
                 "lightningcss": "^1.21.0",
                 "sass": "*",
@@ -3710,13 +3909,13 @@
             }
         },
         "node_modules/vite-plugin-mkcert": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.16.0.tgz",
-            "integrity": "sha512-5r+g8SB9wZzLNUFekGwZo3e0P6QlS6rbxK5p9z/itxNAimsYohgjK/YfVPVxM9EuglP9hjridq0lUejo9v1nVg==",
+            "version": "1.17.4",
+            "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.17.4.tgz",
+            "integrity": "sha512-P/B/tXhsUdpFO4Go1f2obu8WL3xxA3lbsbz4YzflbWfqWl15uwFiXaiCCBztJu1f4WnilrdXYihGrGT9jU743A==",
             "dev": true,
             "dependencies": {
-                "@octokit/rest": "^19.0.5",
-                "axios": "^1.2.2",
+                "@octokit/rest": "^20.0.2",
+                "axios": "^1.6.5",
                 "debug": "^4.3.4",
                 "picocolors": "^1.0.0"
             },
@@ -3725,22 +3924,6 @@
             },
             "peerDependencies": {
                 "vite": ">=3"
-            }
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -13,19 +13,19 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@pexip/plugin-api": "18.0.0",
+        "@pexip/plugin-api": "19.1.0",
         "eventemitter3": "^5.0.1"
     },
     "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.9.0",
-        "eslint": "^8.52.0",
-        "eslint-config-standard-with-typescript": "^39.1.1",
-        "eslint-plugin-import": "^2.29.0",
-        "eslint-plugin-n": "^16.2.0",
+        "@typescript-eslint/eslint-plugin": "^6.4.0",
+        "eslint": "^8.57.0",
+        "eslint-config-standard-with-typescript": "^43.0.1",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
-        "prettier": "^3.0.3",
-        "typescript": "^5.2.2",
-        "vite": "^4.5.0",
-        "vite-plugin-mkcert": "^1.16.0"
+        "prettier": "^3.2.5",
+        "typescript": "^5.4.2",
+        "vite": "^5.1.6",
+        "vite-plugin-mkcert": "^1.17.4"
     }
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -21,17 +21,17 @@ interface User {
 
 const getAuthUrl = async (): Promise<string> => {
   const authPath = '/api/v2/oauth2/authorize'
-  const url = new URL(authPath, config.vbrick.url)
-  url.searchParams.set('client_id', config.vbrick.client_id)
+  const url = new URL(authPath, config.vbrick.url as string)
+  url.searchParams.set('client_id', config.vbrick.client_id as string)
   url.searchParams.set('code_challenge', await generateCodeChallenge())
   url.searchParams.set('response_type', 'code')
-  url.searchParams.set('redirect_uri', config.vbrick.redirect_uri)
+  url.searchParams.set('redirect_uri', config.vbrick.redirect_uri as string)
   return url.toString()
 }
 
 const createAccessToken = async (code: string): Promise<void> => {
   const path = '/api/v2/oauth2/token'
-  const url = new URL(path, config.vbrick.url)
+  const url = new URL(path, config.vbrick.url as string)
 
   const body = {
     code: code.replace(/ /g, '+'),
@@ -68,7 +68,7 @@ const refreshAccessToken = async (): Promise<void> => {
   }
 
   const path = '/api/v2/oauth2/token'
-  const url = new URL(path, config.vbrick.url)
+  const url = new URL(path, config.vbrick.url as string)
 
   const body = {
     grant_type: 'refresh_token',
@@ -92,7 +92,7 @@ const refreshAccessToken = async (): Promise<void> => {
 
 const isSessionValid = async (): Promise<boolean> => {
   const path = '/api/v2/user/session'
-  const url = new URL(path, config.vbrick.url)
+  const url = new URL(path, config.vbrick.url as string)
   const response = await fetch(url, {
     headers: {
       Authorization: `vbrick ${user?.access_token}`
@@ -107,7 +107,7 @@ const isSessionValid = async (): Promise<boolean> => {
 const logout = async (): Promise<void> => {
   // Send the request to logoff endpoint
   const path = '/api/v2/user/logoff'
-  const url = new URL(path, config.vbrick.url)
+  const url = new URL(path, config.vbrick.url as string)
   await fetch(url, {
     method: 'POST',
     body: JSON.stringify({

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,5 +40,5 @@ await initButton()
 if (await Auth.isSessionValid()) {
   await Auth.refreshAccessToken()
 } else {
-  await Auth.cleanSession()
+  Auth.cleanSession()
 }

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -21,7 +21,7 @@ const init = (): void => {
   })
 
   plugin.events.participantJoined.add(async (event) => {
-    const vbrickHostname = new URL(config.vbrick.url).hostname
+    const vbrickHostname = new URL(config.vbrick.url as string).hostname
 
     if (event.participant.uri.split('@')[1] === vbrickHostname) {
       (plugin.conference as any).sendRequest({
@@ -40,7 +40,7 @@ const init = (): void => {
   })
 
   plugin.events.participantLeft.add((event) => {
-    const vbrickHostname = new URL(config.vbrick.url).hostname
+    const vbrickHostname = new URL(config.vbrick.url as string).hostname
 
     if (event.participant.uri.split('@')[1] === vbrickHostname) {
       (plugin.conference as any).sendRequest({
@@ -60,7 +60,7 @@ const init = (): void => {
   plugin.events.participants.add(async (event) => {
     participants = event.participants
 
-    const domain = new URL(config.vbrick.url).hostname
+    const domain = new URL(config.vbrick.url as string).hostname
     const recordingUri = `sip:${Auth.getUser()?.username}@${domain}`
 
     const recordingParticipant = participants.find((participant) => {
@@ -94,7 +94,7 @@ const startRecording = async (): Promise<void> => {
   const pin = ''
 
   const path = '/api/v2/vc/start-recording'
-  const url = new URL(path, config.vbrick.url)
+  const url = new URL(path, config.vbrick.url as string)
 
   const body = {
     title: uri,
@@ -126,7 +126,7 @@ const stopRecording = async (): Promise<void> => {
   const plugin = getPlugin()
 
   const path = '/api/v2/vc/stop-recording'
-  const url = new URL(path, config.vbrick.url)
+  const url = new URL(path, config.vbrick.url as string)
 
   const body = { videoId }
 
@@ -159,7 +159,7 @@ const isAnotherRecordingActive = (): boolean => {
   if (participants == null) {
     return false
   }
-  const vbrickDomain = new URL(config.vbrick.url).hostname
+  const vbrickDomain = new URL(config.vbrick.url as string).hostname
   const recordingParticipant = participants.find((participant) => {
     const domain = participant.uri.split('@')[1]
     return domain === vbrickDomain

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -59,23 +59,13 @@ const init = (): void => {
   // case the user reload the page
   plugin.events.participants.add(async (event) => {
     participants = event.participants
+  })
 
-    const domain = new URL(config.vbrick.url as string).hostname
-    const recordingUri = `sip:${Auth.getUser()?.username}@${domain}`
-
-    const recordingParticipant = participants.find((participant) => {
-      return participant.uri === recordingUri
-    })
-
-    if (recordingParticipant != null) {
-      if (isRecording()) {
-        videoId = ''
-      } else {
-        videoId = localStorage.getItem(localStorageKey) ?? ''
-        if (videoId !== '') {
-          await initButtonGroup()
-        }
-      }
+  plugin.events.participantLeft.add(async (event) => {
+    const participant = event.participant
+    if (isRecordingParticipant(participant)) {
+      videoId = ''
+      await initButtonGroup()
     }
   })
 }
@@ -166,6 +156,13 @@ const isAnotherRecordingActive = (): boolean => {
   })
   const active = recordingParticipant != null
   return active
+}
+
+const isRecordingParticipant = (participant: InfinityParticipant): boolean => {
+  const domain = new URL(config.vbrick.url as string).hostname
+  const recordingUri = `sip:${Auth.getUser()?.username}@${domain}`
+
+  return participant.uri === recordingUri
 }
 
 const emitter = new EventEmitter()


### PR DESCRIPTION
The token expires after 30 minutes, so it will only fail if the duration of the call is higher that 30 minutes. The current problem appears because the `videoId` is missing due a wrong implementation in the `participants`  event. This PR includes the following:

- Update all the dependencies.
- Fix the problem related to the `videoId`.
- Implement the refreshToken before the expired time.